### PR TITLE
build: eliminate warnings

### DIFF
--- a/include/greybus/platform.h
+++ b/include/greybus/platform.h
@@ -27,7 +27,7 @@ struct device;
  * @return -ENOMEM if memory could not be allocated
  * @return -EALREADY if at least one of @p cport or @dev has already been mapped
  */
-int gb_add_cport_device_mapping(unsigned int cport, struct device *dev);
+int gb_add_cport_device_mapping(unsigned int cport, const struct device *dev);
 
 /**
  * @brief Query the Greybus cport / device mapping for @p dev
@@ -39,7 +39,7 @@ int gb_add_cport_device_mapping(unsigned int cport, struct device *dev);
  * @return the associated cport on success (which is >= 0)
  * @return -ENOENT on failure
  */
-int gb_device_to_cport(struct device *dev);
+int gb_device_to_cport(const struct device *dev);
 
 /**
  * @brief Query the Greybus cport / device mapping for @p cport
@@ -51,16 +51,16 @@ int gb_device_to_cport(struct device *dev);
  * @return a pointer to the associated Zephyr @ref device on success
  * @return NULL on failure
  */
-struct device *gb_cport_to_device(unsigned int cport);
+const struct device *gb_cport_to_device(unsigned int cport);
 
 struct gb_spi_master_config_response;
 struct gb_spi_device_config_response;
 struct spi_cs_control;
 struct gb_platform_spi_api {
-	int (*controller_config_response)(struct device *dev, struct gb_spi_master_config_response *rsp);
-	int (*num_peripherals)(struct device *dev);
-	int (*peripheral_config_response)(struct device *dev, uint8_t chip_select, struct gb_spi_device_config_response *rsp);
-	int (*get_cs_control)(struct device *dev, uint8_t chip_select, struct spi_cs_control *ctrl);
+	int (*controller_config_response)(const struct device *dev, struct gb_spi_master_config_response *rsp);
+	int (*num_peripherals)(const struct device *dev);
+	int (*peripheral_config_response)(const struct device *dev, uint8_t chip_select, struct gb_spi_device_config_response *rsp);
+	int (*get_cs_control)(const struct device *dev, uint8_t chip_select, struct spi_cs_control *ctrl);
 };
 
 /*
@@ -68,10 +68,10 @@ struct gb_platform_spi_api {
  *
  * usage:
  *
- * struct device *gb_spidev = gb_spidev_from_zephyr_spidev(device_get_binding("SPI_0"));
- * struct gb_platform_spi_api *api = (struct gb_platform_spi_api *)gb_spidev->driver_api;
+ * const struct device *gb_spidev = gb_spidev_from_zephyr_spidev(device_get_binding("SPI_0"));
+ * const struct gb_platform_spi_api *api = (struct gb_platform_spi_api *)gb_spidev->driver_api;
  */
-struct device *gb_spidev_from_zephyr_spidev(struct device *dev);
+const struct device *gb_spidev_from_zephyr_spidev(const struct device *dev);
 
 #ifdef __cplusplus
 }

--- a/samples/subsys/greybus/net/boards/native_posix.conf
+++ b/samples/subsys/greybus/net/boards/native_posix.conf
@@ -1,4 +1,6 @@
 # Copyright (c) 2020 Friedt Professional Engineering Services, Inc
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_GPIO=y
 CONFIG_GPIO_EMUL=y
+CONFIG_GREYBUS_GPIO=y

--- a/samples/subsys/greybus/net/boards/native_posix_64.conf
+++ b/samples/subsys/greybus/net/boards/native_posix_64.conf
@@ -1,4 +1,6 @@
 # Copyright (c) 2020 Friedt Professional Engineering Services, Inc
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_GPIO=y
 CONFIG_GPIO_EMUL=y
+CONFIG_GREYBUS_GPIO=y

--- a/samples/subsys/greybus/net/src/main.c
+++ b/samples/subsys/greybus/net/src/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <zephyr.h>
 
+struct device;
 extern int greybus_service_init(struct device *bus);
 
 void main(void)

--- a/samples/subsys/greybus/uart/src/main.c
+++ b/samples/subsys/greybus/uart/src/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <zephyr.h>
 
+struct device;
 extern int greybus_service_init(struct device *bus);
 
 void main(void)

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -67,7 +67,7 @@ static uint8_t gb_gpio_protocol_version(struct gb_operation *operation)
 static uint8_t gb_gpio_line_count(struct gb_operation *operation)
 {
 	struct gb_gpio_line_count_response *response;
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	uint8_t count;
 
@@ -94,7 +94,7 @@ static uint8_t gb_gpio_line_count(struct gb_operation *operation)
 
 static uint8_t gb_gpio_activate(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_activate_request *request =
 		gb_operation_get_request_payload(operation);
@@ -122,7 +122,7 @@ static uint8_t gb_gpio_activate(struct gb_operation *operation)
 
 static uint8_t gb_gpio_deactivate(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_activate_request *request =
 		gb_operation_get_request_payload(operation);
@@ -150,7 +150,7 @@ static uint8_t gb_gpio_deactivate(struct gb_operation *operation)
 
 static uint8_t gb_gpio_get_direction(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_get_direction_response *response;
 	struct gb_gpio_get_direction_request *request =
@@ -184,7 +184,7 @@ static uint8_t gb_gpio_get_direction(struct gb_operation *operation)
 
 static uint8_t gb_gpio_direction_in(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_direction_in_request *request =
 		gb_operation_get_request_payload(operation);
@@ -211,7 +211,7 @@ static uint8_t gb_gpio_direction_in(struct gb_operation *operation)
 static uint8_t gb_gpio_direction_out(struct gb_operation *operation)
 {
 	int ret;
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_direction_out_request *request =
 		gb_operation_get_request_payload(operation);
@@ -247,7 +247,7 @@ static uint8_t gb_gpio_direction_out(struct gb_operation *operation)
 
 static uint8_t gb_gpio_get_value(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_get_value_response *response;
 	struct gb_gpio_get_value_request *request =
@@ -279,7 +279,7 @@ static uint8_t gb_gpio_get_value(struct gb_operation *operation)
 
 static uint8_t gb_gpio_set_value(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_set_value_request *request =
 		gb_operation_get_request_payload(operation);
@@ -305,7 +305,7 @@ static uint8_t gb_gpio_set_value(struct gb_operation *operation)
 
 static uint8_t gb_gpio_set_debounce(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_set_debounce_request *request =
 		gb_operation_get_request_payload(operation);
@@ -335,7 +335,7 @@ static uint8_t gb_gpio_set_debounce(struct gb_operation *operation)
 
 static uint8_t gb_gpio_irq_mask(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_irq_mask_request *request =
 		gb_operation_get_request_payload(operation);
@@ -361,7 +361,7 @@ static uint8_t gb_gpio_irq_mask(struct gb_operation *operation)
 
 static uint8_t gb_gpio_irq_unmask(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_irq_unmask_request *request =
 		gb_operation_get_request_payload(operation);
@@ -389,7 +389,7 @@ int gb_gpio_irq_event(int irq, void *context, void *priv)
 {
 	struct gb_gpio_irq_event_request *request;
 	struct gb_operation *operation;
-	struct device *dev = (struct device *)context;
+	const struct device *dev = (const struct device *)context;
 	int cport = gb_device_to_cport(dev);
 
 	if (cport < 0) {
@@ -417,7 +417,7 @@ int gb_gpio_irq_event(int irq, void *context, void *priv)
 
 static uint8_t gb_gpio_irq_type(struct gb_operation *operation)
 {
-	struct device *dev;
+	const struct device *dev;
 	const struct gpio_driver_config *cfg;
 	struct gb_gpio_irq_type_request *request =
 		gb_operation_get_request_payload(operation);

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -160,7 +160,7 @@ static int gb_i2c_init(unsigned int cport, struct gb_bundle *bundle)
 {
 	__ASSERT_NO_MSG(bundle != NULL);
 
-    bundle->dev = gb_cport_to_device(cport);
+    bundle->dev = (struct device *)gb_cport_to_device(cport);
     if (!bundle->dev) {
         return -EIO;
     }

--- a/subsys/greybus/platform/bundle.c
+++ b/subsys/greybus/platform/bundle.c
@@ -15,13 +15,12 @@ struct greybus_bundle_config {
     const char *const bus_name;
 };
 
-static int greybus_bundle_init(struct device *dev) {
+static int greybus_bundle_init(const struct device *dev) {
 
 	const struct greybus_bundle_config *const config =
 			(const struct greybus_bundle_config *)dev->config;
 
-	int r;
-	struct device *bus;
+	const struct device *bus;
 
 	bus = device_get_binding(config->bus_name);
 	if (NULL == bus) {
@@ -34,8 +33,8 @@ static int greybus_bundle_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_bundle_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_bundle_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_bundle_init);
 }
 

--- a/subsys/greybus/platform/bus.c
+++ b/subsys/greybus/platform/bus.c
@@ -14,11 +14,10 @@ struct greybus_config {
     const uint8_t version_minor;
 };
 
-static int greybus_init(struct device *bus) {
+static int greybus_init(const struct device *bus) {
 
 	const struct greybus_config *const config =
 			(const struct greybus_config *)bus->config;
-	int r;
 
 	LOG_DBG("probed greybus: %u major: %u minor: %u",
 		config->id, config->version_major, config->version_minor);

--- a/subsys/greybus/platform/control.c
+++ b/subsys/greybus/platform/control.c
@@ -15,16 +15,15 @@ struct greybus_control_config {
     const char *bus_name;
 };
 
-static int greybus_control_init(struct device *dev) {
+static int greybus_control_init(const struct device *dev) {
 
     struct greybus_control_config *config =
         (struct greybus_control_config *)dev->config;
-    int r;
-    struct device *bus;
+    const struct device *bus;
 
     bus = device_get_binding(config->bus_name);
     if (NULL == bus) {
-		LOG_ERR("control: failed to get binding for device '%s'", config->bus_name);
+	LOG_ERR("control: failed to get binding for device '%s'", config->bus_name);
     	return -ENODEV;
     }
 
@@ -34,8 +33,8 @@ static int greybus_control_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_control_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_control_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_control_init);
 }
 

--- a/subsys/greybus/platform/gpio.c
+++ b/subsys/greybus/platform/gpio.c
@@ -1,6 +1,7 @@
 #include <drivers/gpio.h>
 #include <dt-bindings/greybus/greybus.h>
 #include <greybus/greybus.h>
+#include <greybus/platform.h>
 #include <stdint.h>
 #include <sys/byteorder.h>
 #include <zephyr.h>
@@ -23,11 +24,11 @@ struct greybus_gpio_control_config {
 };
 
 struct greybus_gpio_control_data {
-    struct device *greybus_gpio_controller;
+    const struct device *greybus_gpio_controller;
     struct gpio_callback callback;
 };
 
-static void gpio_callback_handler(struct device *port,
+static void gpio_callback_handler(const struct device *port,
 					struct gpio_callback *cb,
 					gpio_port_pins_t pins)
 {
@@ -77,14 +78,14 @@ static void gpio_callback_handler(struct device *port,
 	}
 }
 
-static int greybus_gpio_control_init(struct device *dev) {
+static int greybus_gpio_control_init(const struct device *dev) {
 
 	struct greybus_gpio_control_data *drv_data =
         (struct greybus_gpio_control_data *)dev->data;
     struct greybus_gpio_control_config *config =
         (struct greybus_gpio_control_config *)dev->config;
     int r;
-    struct device *bus;
+    const struct device *bus;
     gpio_port_pins_t mask;
 
     drv_data->greybus_gpio_controller =
@@ -124,8 +125,8 @@ static int greybus_gpio_control_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_gpio_control_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_gpio_control_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_gpio_control_init);
 }
 

--- a/subsys/greybus/platform/i2c.c
+++ b/subsys/greybus/platform/i2c.c
@@ -1,6 +1,7 @@
 #include <drivers/i2c.h>
 #include <dt-bindings/greybus/greybus.h>
 #include <greybus/greybus.h>
+#include <greybus/platform.h>
 #include <stdint.h>
 #include <sys/byteorder.h>
 #include <zephyr.h>
@@ -23,17 +24,17 @@ struct greybus_i2c_control_config {
 };
 
 struct greybus_i2c_control_data {
-    struct device *greybus_i2c_controller;
+    const struct device *greybus_i2c_controller;
 };
 
-static int greybus_i2c_control_init(struct device *dev) {
+static int greybus_i2c_control_init(const struct device *dev) {
 
 	struct greybus_i2c_control_data *drv_data =
         (struct greybus_i2c_control_data *)dev->data;
     struct greybus_i2c_control_config *config =
         (struct greybus_i2c_control_config *)dev->config;
     int r;
-    struct device *bus;
+    const struct device *bus;
 
     drv_data->greybus_i2c_controller =
         device_get_binding(config->greybus_i2c_controller_name);
@@ -61,8 +62,8 @@ static int greybus_i2c_control_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_i2c_control_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_i2c_control_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_i2c_control_init);
 }
 

--- a/subsys/greybus/platform/interface.c
+++ b/subsys/greybus/platform/interface.c
@@ -17,13 +17,11 @@ struct greybus_interface_config {
 	const char *const bus_name;
 };
 
-static int greybus_interface_init(struct device *dev) {
+static int greybus_interface_init(const struct device *dev) {
 
 	const struct greybus_interface_config *config =
 		(struct greybus_interface_config *)dev->config;
-
-	struct device *bus;
-	int r;
+	const struct device *bus;
 
 	bus = device_get_binding(config->bus_name);
 	if (NULL == bus) {
@@ -36,8 +34,8 @@ static int greybus_interface_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_interface_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_interface_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_interface_init);
 }
 

--- a/subsys/greybus/platform/manifest.c
+++ b/subsys/greybus/platform/manifest.c
@@ -26,7 +26,7 @@ int manifest_get(uint8_t **mnfb, size_t *mnfb_size)
 	int r = -ENOENT;
 
 	if (IS_ENABLED(CONFIG_GREYBUS_MANIFEST_BUILTIN)) {
-		*mnfb = greybus_manifest_builtin;
+		*mnfb = (uint8_t *)greybus_manifest_builtin;
 		*mnfb_size = sizeof(greybus_manifest_builtin);
 		r = 0;
 	}

--- a/subsys/greybus/platform/platform.c
+++ b/subsys/greybus/platform/platform.c
@@ -18,14 +18,14 @@ LOG_MODULE_REGISTER(greybus_platform);
 
 struct map_entry {
 	unsigned int cport;
-	struct device *dev;
+	const struct device *dev;
 };
 
 static size_t map_size;
 static struct map_entry *map;
 K_MUTEX_DEFINE(map_mutex);
 
-int gb_add_cport_device_mapping(unsigned int cport, struct device *dev)
+int gb_add_cport_device_mapping(unsigned int cport, const struct device *dev)
 {
 	int ret;
 	int mutex_ret;
@@ -79,7 +79,7 @@ unlock:
 	return ret;
 }
 
-int gb_device_to_cport(struct device *dev)
+int gb_device_to_cport(const struct device *dev)
 {
 	int ret;
 	int mutex_ret;
@@ -107,9 +107,9 @@ unlock:
 	return ret;
 }
 
-struct device *gb_cport_to_device(unsigned int cport)
+const struct device *gb_cport_to_device(unsigned int cport)
 {
-	struct device *ret;
+	const struct device *ret;
 	int mutex_ret;
 	size_t idx;
 	struct map_entry *entry;

--- a/subsys/greybus/platform/service.c
+++ b/subsys/greybus/platform/service.c
@@ -42,7 +42,7 @@ gb_transport_get_backend(void)
 	return xport;
 }
 
-int greybus_service_init(struct device *bus)
+int greybus_service_init(const struct device *bus)
 {
     int r;
 	uint8_t *mnfb;
@@ -76,6 +76,7 @@ int greybus_service_init(struct device *bus)
 		goto out;
 	}
 
+	extern size_t manifest_get_num_cports(void);
 	num_cports = manifest_get_num_cports();
     if (num_cports == 0) {
 		LOG_ERR("no cports are defined");

--- a/subsys/greybus/platform/string.c
+++ b/subsys/greybus/platform/string.c
@@ -14,12 +14,10 @@ struct greybus_string_config {
     const char *const bus_name;
 };
 
-static int greybus_string_init(struct device *dev) {
+static int greybus_string_init(const struct device *dev) {
 	const struct greybus_string_config *config =
 			(const struct greybus_string_config *)dev->config;
-
-	struct device *bus;
-	int r;
+	const struct device *bus;
 
 	bus = device_get_binding(config->bus_name);
 	if (NULL == bus) {
@@ -32,8 +30,8 @@ static int greybus_string_init(struct device *dev) {
     return 0;
 }
 
-extern int gb_service_defer_init(struct device *, int (*init)(struct device *));
-static int defer_greybus_string_init(struct device *dev) {
+extern int gb_service_defer_init(const struct device *, int (*init)(const struct device *));
+static int defer_greybus_string_init(const struct device *dev) {
 	return gb_service_defer_init(dev, &greybus_string_init);
 }
 

--- a/subsys/greybus/platform/transport-tcpip.c
+++ b/subsys/greybus/platform/transport-tcpip.c
@@ -20,6 +20,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+/* For some reason, not declared even with _GNU_SOURCE */
+extern int pthread_setname_np(pthread_t thread, const char *name);
+
 /* For some reason, including <net/net_ip.h> breaks everything
  * I only need these */
 static inline struct sockaddr_in *net_sin(struct sockaddr *sa)
@@ -647,7 +650,7 @@ static int netsetup(size_t num_cports)
 {
 	int r;
 	int fd;
-    size_t i;
+	size_t i;
 	const int yes = true;
 	int family;
 	uint16_t *port;
@@ -680,7 +683,7 @@ static int netsetup(size_t num_cports)
         }
 
         if (!fd_context_insert(fd, i, FD_CONTEXT_SERVER)) {
-        	LOG_ERR("failed to add fd context for cport %d", i);
+        	LOG_ERR("failed to add fd context for cport %zu", i);
         	close(fd);
         	return -EINVAL;
         }
@@ -704,7 +707,7 @@ static int netsetup(size_t num_cports)
             return -errno;
         }
 
-        LOG_INF("CPort %d mapped to TCP/IP port %u",
+        LOG_INF("CPort %zu mapped to TCP/IP port %zu",
 			i, GB_TRANSPORT_TCPIP_BASE_PORT + i);
     }
 

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -76,16 +76,16 @@ static uint8_t gb_spi_protocol_version(struct gb_operation *operation)
     return GB_OP_SUCCESS;
 }
 
-static int device_spi_get_master_config(struct device *dev, struct gb_spi_master_config_response *response)
+static int device_spi_get_master_config(const struct device *dev, struct gb_spi_master_config_response *response)
 {
     int ret;
 
-    struct device *const gb_spidev = gb_spidev_from_zephyr_spidev(dev);
+    const struct device *gb_spidev = gb_spidev_from_zephyr_spidev(dev);
     if (gb_spidev == NULL) {
     	return -ENODEV;
     }
 
-    const struct gb_platform_spi_api *const api = gb_spidev->api;
+    const struct gb_platform_spi_api *api = gb_spidev->api;
     __ASSERT_NO_MSG(api != NULL);
 
     ret = api->controller_config_response(gb_spidev, response);
@@ -127,12 +127,12 @@ static uint8_t gb_spi_protocol_master_config(struct gb_operation *operation)
     return GB_OP_SUCCESS;
 }
 
-static int device_spi_get_device_config(struct device *dev, uint8_t cs, struct gb_spi_device_config_response *response)
+static int device_spi_get_device_config(const struct device *dev, uint8_t cs, struct gb_spi_device_config_response *response)
 {
     int ret;
 
-    struct device *const gb_spidev = gb_spidev_from_zephyr_spidev(dev);
-    struct gb_platform_spi_api *const api = (struct gb_platform_spi_api *)gb_spidev->api;
+    const struct device *gb_spidev = gb_spidev_from_zephyr_spidev(dev);
+    const struct gb_platform_spi_api *api = (struct gb_platform_spi_api *)gb_spidev->api;
     __ASSERT_NO_MSG(api != NULL);
 
     ret = api->peripheral_config_response(gb_spidev, cs, response);
@@ -186,15 +186,15 @@ static uint8_t gb_spi_protocol_device_config(struct gb_operation *operation)
 }
 
 static int request_to_spi_config(const struct gb_spi_transfer_request *const request,
-	const size_t freq, const uint8_t bits_per_word, struct device *const spi_dev, struct spi_config *const spi_config, struct spi_cs_control *ctrl)
+	const size_t freq, const uint8_t bits_per_word, const struct device *spi_dev, struct spi_config *const spi_config, struct spi_cs_control *ctrl)
 {
-    struct device *const gb_spidev = gb_spidev_from_zephyr_spidev(spi_dev);
+    const struct device *gb_spidev = gb_spidev_from_zephyr_spidev(spi_dev);
 
     if (gb_spidev == NULL) {
     	return -ENODEV;
     }
 
-    const struct gb_platform_spi_api *const api = gb_spidev->api;
+    const struct gb_platform_spi_api *api = gb_spidev->api;
     __ASSERT_NO_MSG(api != NULL);
 
     spi_config->frequency = freq;
@@ -439,7 +439,7 @@ out:
  */
 static int gb_spi_init(unsigned int cport, struct gb_bundle *bundle)
 {
-    bundle->dev = gb_cport_to_device(cport);
+    bundle->dev = (struct device *)gb_cport_to_device(cport);
     if (!bundle->dev) {
         return -EIO;
     }

--- a/tests/subsys/greybus/gpio/src/gpio-sim.c
+++ b/tests/subsys/greybus/gpio/src/gpio-sim.c
@@ -17,7 +17,7 @@
  * correspondingly, as if a wire were connecting the two.
  */
 
-static void gpio_emul_callback_handler(struct device *port,
+static void gpio_emul_callback_handler(const struct device *port,
 				      struct gpio_callback *cb,
 				      gpio_port_pins_t pins)
 {
@@ -65,7 +65,7 @@ static struct gpio_callback gpio_emul_callback = {
 
 void gpio_emul_setup(void)
 {
-	struct device *dev = device_get_binding(GPIO_DEV_NAME);
+	const struct device *dev = device_get_binding(GPIO_DEV_NAME);
 	__ASSERT(dev != NULL, "Device not found");
 	int rc = gpio_add_callback(dev, &gpio_emul_callback);
 	__ASSERT(rc == 0, "gpio_add_callback() failed: %d", rc);

--- a/tests/subsys/greybus/gpio/src/gpio.c
+++ b/tests/subsys/greybus/gpio/src/gpio.c
@@ -85,9 +85,10 @@ void test_greybus_setup(void) {
 
 	*port = htons(PORT);
 
-    greybus_service_init();
+	extern int greybus_service_init(const struct device *);
+	greybus_service_init(NULL);
 
-	gpio_dev = device_get_binding(GPIO_DEV_NAME);
+	gpio_dev = (struct device *)device_get_binding(GPIO_DEV_NAME);
 	zassert_not_equal(gpio_dev, NULL, "failed to get device binding for " GPIO_DEV_NAME);
 
     r = socket(family, SOCK_STREAM, 0);
@@ -434,7 +435,7 @@ void test_greybus_gpio_get_value(void)
      * we will subsequently read
      */
     if (gpio_dev == NULL) {
-        gpio_dev = device_get_binding(GPIO_DEV_NAME);
+        gpio_dev = (struct device *)device_get_binding(GPIO_DEV_NAME);
         zassert_not_equal(gpio_dev, NULL, "failed to get device binding for " GPIO_DEV_NAME);
     }
     r = gpio_pin_set(gpio_dev, GPIO_PIN_OUT, 1);

--- a/zephyr-gpio-get-direction.patch
+++ b/zephyr-gpio-get-direction.patch
@@ -51,7 +51,7 @@ index 44f893a615..43fbf7d01e 100644
 + * @param pin Pin number to query the direction of
 + * @return the direction of the pin
 + */
-+static inline bool gpio_pin_get_direction(struct device *port, gpio_pin_t pin)
++static inline bool gpio_pin_get_direction(const struct device *port, gpio_pin_t pin)
 +{
 +	const struct gpio_driver_config *const cfg =
 +		(const struct gpio_driver_config *)port->config;


### PR DESCRIPTION
This change eliminates a number of compiler warnings.

The main gist was that `struct device *` was replaced
with `const struct device *` in a number of places.

Fixes #1