### PR TITLE
subsys: greybus: update devicetree macros

### DIFF
--- a/samples/subsys/greybus/net/boards/cc1352r1_launchxl.overlay
+++ b/samples/subsys/greybus/net/boards/cc1352r1_launchxl.overlay
@@ -32,12 +32,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		/* NB: string id 0 is invalid */
@@ -46,6 +48,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -53,6 +56,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -61,6 +65,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -73,6 +78,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -87,6 +93,7 @@
 	};
 
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -94,6 +101,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbgpio0 {
+			label = "GBGPIO_0";
 			status = "okay";
 			compatible = "zephyr,greybus-gpio-controller";
 			greybus-gpio-controller = <&gpio0>;
@@ -104,6 +112,7 @@
 	};
 	
 	gbbundle2 {
+		label = "GBBUNDLE_2";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -111,6 +120,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;

--- a/samples/subsys/greybus/net/boards/cc1352r_sensortag.overlay
+++ b/samples/subsys/greybus/net/boards/cc1352r_sensortag.overlay
@@ -44,12 +44,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		/* NB: string id 0 is invalid */
@@ -58,6 +60,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -65,6 +68,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -73,6 +77,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -85,6 +90,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -99,6 +105,7 @@
 	};
 
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -116,6 +123,7 @@
 	};
 	
 	gbbundle2 {
+		label = "GBBUNDLE_2";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -123,6 +131,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;
@@ -133,6 +142,7 @@
 	};
 	
 	gbbundle3 {
+		label = "GBBUNDLE_3";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -140,6 +150,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbspi0 {
+			label = "GBSPI_0";
 			status = "okay";
 			compatible = "zephyr,greybus-spi-controller";
 			greybus-spi-controller = <&spi0>;
@@ -157,6 +168,7 @@
 			flags = <0>;
 
 			gbspidev0 {
+				label = "GBSPIDEV_0";
 				status = "okay";
 				compatible = "zephyr,greybus-spi-peripheral";
 				/* cs is used as an array index */				

--- a/samples/subsys/greybus/net/boards/native_posix.overlay
+++ b/samples/subsys/greybus/net/boards/native_posix.overlay
@@ -19,12 +19,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -32,6 +34,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -39,6 +42,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -47,6 +51,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -59,6 +64,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -73,6 +79,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -80,6 +87,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbgpio0 {
+			label = "GBGPIO_0";
 			status = "okay";
 			compatible = "zephyr,greybus-gpio-controller";
 			greybus-gpio-controller = <&gpio0>;

--- a/samples/subsys/greybus/uart/boards/cc1352r1_launchxl.overlay
+++ b/samples/subsys/greybus/uart/boards/cc1352r1_launchxl.overlay
@@ -32,12 +32,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		/* NB: string id 0 is invalid */
@@ -46,6 +48,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -53,6 +56,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -61,6 +65,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -73,6 +78,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -87,6 +93,7 @@
 	};
 
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -94,6 +101,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbgpio0 {
+			label = "GBGPIO_0";
 			status = "okay";
 			compatible = "zephyr,greybus-gpio-controller";
 			greybus-gpio-controller = <&gpio0>;
@@ -104,6 +112,7 @@
 	};
 	
 	gbbundle2 {
+		label = "GBBUNDLE_2";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -111,6 +120,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;

--- a/samples/subsys/greybus/uart/boards/cc1352r_sensortag.overlay
+++ b/samples/subsys/greybus/uart/boards/cc1352r_sensortag.overlay
@@ -44,12 +44,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		/* NB: string id 0 is invalid */
@@ -58,6 +60,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -65,6 +68,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -73,6 +77,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -85,6 +90,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -99,6 +105,7 @@
 	};
 
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -106,6 +113,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbgpio0 {
+			label = "GBGPIO_0";
 			status = "okay";
 			compatible = "zephyr,greybus-gpio-controller";
 			greybus-gpio-controller = <&gpio0>;
@@ -116,6 +124,7 @@
 	};
 	
 	gbbundle2 {
+		label = "GBBUNDLE_2";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -123,6 +132,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;
@@ -133,6 +143,7 @@
 	};
 	
 	gbbundle3 {
+		label = "GBBUNDLE_3";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -140,6 +151,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbspi0 {
+			label = "GBSPI_0";
 			status = "okay";
 			compatible = "zephyr,greybus-spi-controller";
 			greybus-spi-controller = <&spi0>;
@@ -157,6 +169,7 @@
 			flags = <0>;
 
 			gbspidev0 {
+				label = "GBSPIDEV_0";
 				status = "okay";
 				compatible = "zephyr,greybus-spi-peripheral";
 				/* cs is used as an array index */				

--- a/subsys/greybus/platform/bundle.c
+++ b/subsys/greybus/platform/bundle.c
@@ -48,11 +48,11 @@ static int defer_greybus_bundle_init(const struct device *dev) {
 					DT_LABEL(DT_PARENT(DT_DRV_INST(_num))),				\
         };                                                              \
                                                                         \
-        DEVICE_INIT(greybus_bundle_##_num, "GBBUNDLE_" #_num,			\
-                            defer_greybus_bundle_init,						\
-							NULL,										\
+        DEVICE_DT_INST_DEFINE(_num,										\
+                            defer_greybus_bundle_init,					\
+							NULL, NULL,									\
                             &greybus_bundle_config_##_num,				\
 							POST_KERNEL,								\
-                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GREYBUS_BUNDLE);

--- a/subsys/greybus/platform/bus.c
+++ b/subsys/greybus/platform/bus.c
@@ -36,9 +36,8 @@ static int greybus_init(const struct device *bus) {
 					DT_INST_PROP(_num, version_minor),	\
         };												\
         												\
-        DEVICE_AND_API_INIT(greybus_##_num,				\
-			"GREYBUS_" #_num,							\
-			greybus_init, NULL,			\
+		DEVICE_DT_INST_DEFINE(_num,						\
+			greybus_init, NULL,	NULL,					\
 			&greybus_config_##_num, POST_KERNEL,		\
 			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
 			NULL);

--- a/subsys/greybus/platform/control.c
+++ b/subsys/greybus/platform/control.c
@@ -54,10 +54,10 @@ static int defer_greybus_control_init(const struct device *dev) {
 					DT_LABEL(DT_PARENT(DT_PARENT(DT_DRV_INST(_num)))),		\
         };																	\
         																	\
-        DEVICE_INIT(gpio_control_##_num, "GBCONTROL_" #_num,				\
+		DEVICE_DT_INST_DEFINE(_num,											\
                             defer_greybus_control_init,						\
-							NULL,											\
+							NULL, NULL,										\
                             &greybus_control_config_##_num, POST_KERNEL,	\
-                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GREYBUS_CONTROL);

--- a/subsys/greybus/platform/gpio.c
+++ b/subsys/greybus/platform/gpio.c
@@ -140,22 +140,22 @@ static int defer_greybus_gpio_control_init(const struct device *dev) {
 																				\
 		static struct greybus_gpio_control_config								\
 			greybus_gpio_control_config_##_num = {								\
-                .id = (uint8_t)DT_INST_PROP(_num, id), \
-                .bundle = (uint8_t)DT_PROP(DT_PARENT(DT_DRV_INST(_num)), id), \
+                .id = (uint8_t)DT_INST_PROP(_num, id), 							\
+                .bundle = (uint8_t)DT_PROP(DT_PARENT(DT_DRV_INST(_num)), id), 	\
 				.greybus_gpio_controller_name = 								\
                     DT_LABEL(DT_PHANDLE(DT_DRV_INST(_num), 						\
                     		greybus_gpio_controller)), 							\
-				.bus_name = 									\
-					DT_LABEL(DT_PARENT(DT_PARENT(DT_DRV_INST(_num)))),		\
+				.bus_name = 													\
+					DT_LABEL(DT_PARENT(DT_PARENT(DT_DRV_INST(_num)))),			\
         };																		\
         																		\
         static struct greybus_gpio_control_data									\
 			greybus_gpio_control_data_##_num;									\
         																		\
-        DEVICE_INIT(gpio_gpio_control_##_num, "GBGPIO_" #_num,					\
-                            defer_greybus_gpio_control_init,					\
+        DEVICE_DT_INST_DEFINE(_num, 											\
+                            defer_greybus_gpio_control_init, NULL,				\
 							&greybus_gpio_control_data_##_num,					\
                             &greybus_gpio_control_config_##_num, POST_KERNEL,	\
-                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GREYBUS_GPIO_CONTROL);

--- a/subsys/greybus/platform/interface.c
+++ b/subsys/greybus/platform/interface.c
@@ -55,11 +55,10 @@ static int defer_greybus_interface_init(const struct device *dev) {
 				DT_LABEL(DT_PARENT(DT_DRV_INST(_num))),		\
         };													\
         													\
-        DEVICE_INIT(greybus_interface_##_num,				\
-			"GBINTERFACE_" #_num,							\
+        DEVICE_DT_INST_DEFINE(_num, 						\
 			defer_greybus_interface_init,					\
-			NULL,											\
+			NULL, NULL,										\
 			&greybus_interface_config_##_num, POST_KERNEL,	\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+			CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GREYBUS_INTERFACE);

--- a/subsys/greybus/platform/spi.c
+++ b/subsys/greybus/platform/spi.c
@@ -323,7 +323,7 @@ static const struct gb_platform_spi_api gb_platform_spi_api = {
         static struct greybus_spi_control_data									\
 			greybus_spi_control_data_##_num;									\
         																		\
-        DEVICE_AND_API_INIT(spi_spi_control_##_num, "GBSPI_" #_num,					\
+        DEVICE_DT_INST_DEFINE(_num, 										\
                             defer_greybus_spi_control_init,					\
 							&greybus_spi_control_data_##_num,					\
                             &greybus_spi_control_config_##_num, POST_KERNEL,	\

--- a/subsys/greybus/platform/string.c
+++ b/subsys/greybus/platform/string.c
@@ -45,9 +45,9 @@ static int defer_greybus_string_init(const struct device *dev) {
 					DT_LABEL(DT_PARENT(DT_DRV_INST(_num))),				\
         };                                                              \
                                                                         \
-        DEVICE_INIT(greybus_string_##_num, "GBSTRING_" #_num,			\
-        		defer_greybus_string_init, NULL,               	\
+		DEVICE_DT_INST_DEFINE(_num,										\
+        					defer_greybus_string_init, NULL, NULL,		\
                             &greybus_string_config_##_num, POST_KERNEL,	\
-                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+                            CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GREYBUS_STRING);

--- a/tests/subsys/greybus/gpio/boards/native_posix.overlay
+++ b/tests/subsys/greybus/gpio/boards/native_posix.overlay
@@ -25,12 +25,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -38,6 +40,7 @@
 	};
 
 	gbstring2: gbstring2 {
+		label = "GBSTRING_2";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <2>;
@@ -45,6 +48,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring1>;
@@ -53,6 +57,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -65,6 +70,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -79,6 +85,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -86,6 +93,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbgpio0 {
+			label = "GBGPIO_0";
 			status = "okay";
 			compatible = "zephyr,greybus-gpio-controller";
 			greybus-gpio-controller = <&gpio0>;

--- a/tests/subsys/greybus/i2c/boards/cc1352r1_launchxl.overlay
+++ b/tests/subsys/greybus/i2c/boards/cc1352r1_launchxl.overlay
@@ -23,12 +23,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring0: gbstring0 {
+		label = "GBSTRING_0";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <0>;
@@ -36,6 +38,7 @@
 	};
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -43,6 +46,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring0>;
@@ -51,6 +55,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -63,6 +68,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -77,6 +83,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -84,6 +91,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;

--- a/tests/subsys/greybus/i2c/boards/native_posix.overlay
+++ b/tests/subsys/greybus/i2c/boards/native_posix.overlay
@@ -23,12 +23,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring0: gbstring0 {
+		label = "GBSTRING_0";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <0>;
@@ -36,6 +38,7 @@
 	};
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -43,6 +46,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring0>;
@@ -51,6 +55,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -63,6 +68,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -77,6 +83,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -84,6 +91,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;

--- a/tests/subsys/greybus/spi/boards/cc1352r1_launchxl.overlay
+++ b/tests/subsys/greybus/spi/boards/cc1352r1_launchxl.overlay
@@ -23,12 +23,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring0: gbstring0 {
+		label = "GBSTRING_0";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <0>;
@@ -36,6 +38,7 @@
 	};
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_0";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -43,6 +46,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring0>;
@@ -51,6 +55,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -63,6 +68,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -77,6 +83,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -84,6 +91,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbi2c0 {
+			label = "GBI2C_0";
 			status = "okay";
 			compatible = "zephyr,greybus-i2c-controller";
 			greybus-i2c-controller = <&i2c0>;

--- a/tests/subsys/greybus/spi/boards/native_posix.overlay
+++ b/tests/subsys/greybus/spi/boards/native_posix.overlay
@@ -46,12 +46,14 @@
 };
 
 &greybus0 {
+	label = "GREYBUS_0";
 	status = "okay";
 	/* defaults in effect, so this isn't necessary */
 	version-major = <GREYBUS_VERSION_MAJOR>;
 	version-minor = <GREYBUS_VERSION_MINOR>;
 
 	gbstring0: gbstring0 {
+		label = "GBSTRING_0";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <0>;
@@ -59,6 +61,7 @@
 	};
 
 	gbstring1: gbstring1 {
+		label = "GBSTRING_1";
 		status = "okay";
 		compatible = "zephyr,greybus-string";
 		id = <1>;
@@ -66,6 +69,7 @@
 	};
 
 	gbinterface0 {
+		label = "GBINTERFACE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-interface";
 		vendor-string-id = <&gbstring0>;
@@ -74,6 +78,7 @@
 	};
 
 	gbbundle0 {
+		label = "GBBUNDLE_0";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -86,6 +91,7 @@
 		bundle-class = <BUNDLE_CLASS_CONTROL>;
 
 		gbcontrol0 {
+			label = "GBCONTROL_0";
 			status = "okay";
 			compatible = "zephyr,greybus-control";
 			greybus-controller;
@@ -100,6 +106,7 @@
 	};
 	
 	gbbundle1 {
+		label = "GBBUNDLE_1";
 		status = "okay";
 		compatible = "zephyr,greybus-bundle";
 		greybus-bundle;
@@ -107,6 +114,7 @@
 		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
 				
 		gbspi0 {
+			label = "GBSPI_0";
 			status = "okay";
 			compatible = "zephyr,greybus-spi-controller";
 			greybus-spi-controller = <&spi0>;
@@ -125,6 +133,7 @@
 			flags = <GB_SPI_FLAG_HALF_DUPLEX>;
 
 			eeprom {
+				label = "GBSPIDEV_0";
 				status = "okay";
 				compatible = "zephyr,greybus-spi-peripheral";
 				/* cs is used as an array index for compile-time definition [cs] = {...}, */				

--- a/zephyr-gpio-emul.patch
+++ b/zephyr-gpio-emul.patch
@@ -776,8 +776,8 @@ index 000000000000..b3aec93ae460
 +		.flags = gpio_emul_flags_##_num,			\
 +	};								\
 +									\
-+	DEVICE_AND_API_INIT(gpio_emul_##_num, DT_INST_LABEL(_num),	\
-+			    gpio_emul_init, &gpio_emul_data_##_num,	\
++	DEVICE_DT_INST_DEFINE(_num,					\
++			    gpio_emul_init, NULL, &gpio_emul_data_##_num,\
 +			    &gpio_emul_config_##_num, POST_KERNEL,	\
 +			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
 +			    &gpio_emul_driver)


### PR DESCRIPTION
Update devicetree macros / eliminate warnings.

Fixes #39
