### PR TITLE
doc: fix readme to update submodules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,10 @@ Next, clone and synchronize repositories.
     west init -m https://github.com/cfriedt/greybus-for-zephyr.git zephyrproject
     cd zephyrproject
     west update
+    cd greybus
+    git submodule init
+    git submodule update
+    cd ..
 
 While that is updating, choose a board from Zephyr's list of 
 `Supported Boards <https://docs.zephyrproject.org/latest/boards/index.html>`_.
@@ -38,7 +42,7 @@ Lastly, flash firmware for the chosen ``$BOARD`` using the commands below.
 
     cd zephyr
     source zephyr-env.sh
-    git apply ../greybus-for-zephyr.git/zephyr-gpio-get-direction.patch
+    git apply ../greybus/zephyr-gpio-get-direction.patch
     git apply ../greybus/zephyr-gpio-emul.patch
     git apply ../greybus/zephyr-sys-byteorder-posix.patch
     git apply ../greybus/zephyr-aligned-allocators.patch


### PR DESCRIPTION
Kind of messing combinding git submodules and west, but I don't really want to add a manifest for zephyr in the manifesto repository.

Also fix another typo in the readme about applying patches.

Fixes #37