### PR TITLE
subsys: greybus: multiple devices per bundle

### DIFF
--- a/include/greybus-utils/manifest.h
+++ b/include/greybus-utils/manifest.h
@@ -52,6 +52,8 @@ void release_manifest_blob(void *manifest);
 struct list_head *get_manifest_cports(void);
 int get_manifest_size(void);
 size_t manifest_get_max_bundle_id(void);
+size_t manifest_get_num_cports_bundle(int bundle_id);
+unsigned int manifest_get_start_cport_bundle(int bundle_id);
 
 #endif
 

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -107,7 +107,8 @@ struct gb_transport_backend {
 
 struct gb_bundle {
     int id;                     /* bundle ID */
-    struct device *dev;         /* primary bundle device */
+    unsigned int cport_start;   /* start cport */
+    struct device **dev;        /* primary bundle device */
     void *priv;                 /* private bundle data */
 };
 

--- a/samples/subsys/greybus/net/boards/cc1352r_sensortag.overlay
+++ b/samples/subsys/greybus/net/boards/cc1352r_sensortag.overlay
@@ -121,16 +121,7 @@
 			id = <1>;
 			cport-protocol = <CPORT_PROTOCOL_GPIO>;
 		};
-	};
-	
-	gbbundle2 {
-		label = "GBBUNDLE_2";
-		status = "okay";
-		compatible = "zephyr,greybus-bundle";
-		greybus-bundle;
-		id = <2>;
-		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
-				
+
 		gbi2c0 {
 			label = "GBI2C_0";
 			status = "okay";
@@ -140,16 +131,7 @@
 			id = <2>;
 			cport-protocol = <CPORT_PROTOCOL_I2C>;
 		};
-	};
-	
-	gbbundle3 {
-		label = "GBBUNDLE_3";
-		status = "okay";
-		compatible = "zephyr,greybus-bundle";
-		greybus-bundle;
-		id = <3>;
-		bundle-class = <BUNDLE_CLASS_BRIDGED_PHY>;		
-				
+
 		gbspi0 {
 			label = "GBSPI_0";
 			status = "okay";

--- a/subsys/greybus/control-gpb.c
+++ b/subsys/greybus/control-gpb.c
@@ -248,7 +248,7 @@ static uint8_t __attribute__((unused)) gb_control_bundle_pwr_set(struct gb_opera
     struct gb_control_bundle_pwr_set_response *response;
     //struct device_pm_ops *pm_ops;
     struct gb_bundle *bundle;
-    struct device *dev;
+    //struct device *dev;
     int status = 0;
 
     if (gb_operation_get_request_payload_size(operation) < sizeof(*request)) {
@@ -267,7 +267,7 @@ static uint8_t __attribute__((unused)) gb_control_bundle_pwr_set(struct gb_opera
         return GB_OP_INVALID;
     }
 
-    dev = bundle->dev;
+//    dev = bundle->dev;
 //    pm_ops = dev->driver->pm;
 //    if (!pm_ops) {
 //        LOG_INF("pm operations not supported by %s driver", dev->name);

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -66,10 +66,13 @@ static uint8_t gb_gpio_line_count(struct gb_operation *operation)
 {
 	struct gb_gpio_line_count_response *response;
 	const struct device *dev;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	const struct gpio_driver_config *cfg;
 	uint8_t count;
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -94,10 +97,13 @@ static uint8_t gb_gpio_activate(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_activate_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -122,10 +128,13 @@ static uint8_t gb_gpio_deactivate(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_activate_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -150,11 +159,14 @@ static uint8_t gb_gpio_get_direction(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_get_direction_response *response;
 	struct gb_gpio_get_direction_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -184,10 +196,13 @@ static uint8_t gb_gpio_direction_in(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_direction_in_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -211,10 +226,13 @@ static uint8_t gb_gpio_direction_out(struct gb_operation *operation)
 	int ret;
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_direction_out_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -247,11 +265,14 @@ static uint8_t gb_gpio_get_value(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_get_value_response *response;
 	struct gb_gpio_get_value_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -279,10 +300,13 @@ static uint8_t gb_gpio_set_value(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_set_value_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -305,10 +329,13 @@ static uint8_t gb_gpio_set_debounce(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_set_debounce_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -335,10 +362,13 @@ static uint8_t gb_gpio_irq_mask(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_irq_mask_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -361,10 +391,13 @@ static uint8_t gb_gpio_irq_unmask(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_irq_unmask_request *request =
 		gb_operation_get_request_payload(operation);
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -417,12 +450,15 @@ static uint8_t gb_gpio_irq_type(struct gb_operation *operation)
 {
 	const struct device *dev;
 	const struct gpio_driver_config *cfg;
+	struct gb_bundle *bundle = gb_operation_get_bundle(operation);
+	__ASSERT_NO_MSG(bundle != NULL);
+	unsigned int cport_idx = operation->cport - bundle->cport_start;
 	struct gb_gpio_irq_type_request *request =
 		gb_operation_get_request_payload(operation);
 	enum gpio_int_mode mode;
 	enum gpio_int_trig trigger;
 
-	dev = gb_cport_to_device(operation->cport);
+	dev = bundle->dev[cport_idx];
 	if (dev == NULL) {
 		return GB_OP_INVALID;
 	}
@@ -486,7 +522,25 @@ static struct gb_operation_handler gb_gpio_handlers[] = {
 	GB_HANDLER(GB_GPIO_TYPE_IRQ_UNMASK, gb_gpio_irq_unmask),
 };
 
+static int gb_gpio_init(unsigned int cport, struct gb_bundle *bundle)
+{
+	unsigned int cport_idx = cport - bundle->cport_start;
+
+	bundle->dev[cport_idx] = (struct device *)gb_cport_to_device(cport);
+	if (!bundle->dev[cport_idx])
+		return -EIO;
+	return 0;
+}
+
+static void gb_gpio_exit(unsigned int cport, struct gb_bundle *bundle)
+{
+	ARG_UNUSED(cport);
+	ARG_UNUSED(bundle);
+}
+
 struct gb_driver gpio_driver = {
+	.init = gb_gpio_init,
+	.exit = gb_gpio_exit,
 	.op_handlers = (struct gb_operation_handler*) gb_gpio_handlers,
 	.op_handlers_count = ARRAY_SIZE(gb_gpio_handlers),
 };

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -561,6 +561,7 @@ int _gb_register_driver(unsigned int cport, int bundle_id,
     struct gb_bundle *bundle;
 	char thread_name[CONFIG_THREAD_MAX_NAME_LEN];
     int retval;
+	size_t num_cports =  manifest_get_num_cports_bundle(bundle_id);
 
     LOG_DBG("Registering Greybus driver on CP%u", cport);
 
@@ -606,9 +607,11 @@ int _gb_register_driver(unsigned int cport, int bundle_id,
             return -ENOMEM;
 
         bundle->id = bundle_id;
+        bundle->cport_start = manifest_get_start_cport_bundle(bundle_id);
+        bundle->dev = calloc(1, num_cports * sizeof(struct device *));
         g_bundle[bundle_id] = bundle;
     } else {
-        bundle = NULL;
+        bundle = g_bundle[bundle_id]; 
     }
 
     driver->bundle = bundle;

--- a/subsys/greybus/greybus-manifest.c
+++ b/subsys/greybus/greybus-manifest.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <list.h>
 #include <sys/byteorder.h>
@@ -483,6 +484,36 @@ size_t manifest_get_num_cports(void)
 	}
 
 	return r;
+}
+
+size_t manifest_get_num_cports_bundle(int bundle_id)
+{
+	struct gb_cport *gb_cport;
+	struct list_head *iter;
+	size_t r = 0;
+
+	list_foreach(&g_greybus.cports, iter) {
+        gb_cport = list_entry(iter, struct gb_cport, list);
+		if(gb_cport->bundle == bundle_id)
+            		r++;
+	}
+
+	return r;
+}
+
+unsigned int manifest_get_start_cport_bundle(int bundle_id)
+{
+	struct gb_cport *gb_cport;
+	struct list_head *iter;
+	unsigned int cport_id = UINT_MAX;
+
+	list_foreach(&g_greybus.cports, iter) {
+        gb_cport = list_entry(iter, struct gb_cport, list);
+		if(gb_cport->bundle == bundle_id && gb_cport->id < cport_id)
+            cport_id = gb_cport->id;
+	}
+
+	return cport_id;
 }
 
 int get_manifest_size(void)

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -83,6 +83,7 @@ static uint8_t gb_i2c_protocol_transfer(struct gb_operation *operation)
     struct gb_bundle *bundle = gb_operation_get_bundle(operation);
     __ASSERT_NO_MSG(bundle != NULL);
 
+    unsigned int cport_idx = operation->cport - bundle->cport_start;
     struct i2c_msg *requests;
 
     struct gb_i2c_transfer_desc *desc;
@@ -148,7 +149,7 @@ static uint8_t gb_i2c_protocol_transfer(struct gb_operation *operation)
         }
     }
 
-    ret = i2c_transfer(bundle->dev, requests, op_count, addr);
+    ret = i2c_transfer(bundle->dev[cport_idx], requests, op_count, addr);
 
 free_requests:
     free(requests);
@@ -158,10 +159,11 @@ free_requests:
 
 static int gb_i2c_init(unsigned int cport, struct gb_bundle *bundle)
 {
+	unsigned int cport_idx = cport - bundle->cport_start;
 	__ASSERT_NO_MSG(bundle != NULL);
 
-    bundle->dev = (struct device *)gb_cport_to_device(cport);
-    if (!bundle->dev) {
+    bundle->dev[cport_idx] = (struct device *)gb_cport_to_device(cport);
+    if (!bundle->dev[cport_idx]) {
         return -EIO;
     }
 


### PR DESCRIPTION
Fixes https://github.com/cfriedt/greybus-for-zephyr/issues/11

This change adds the ability to have multiple devices on the same bundle, with a restriction that all cports in a bundle must have consecutive cport ID. The devices on a bundle are pointed by bundle->dev with the first cport device pointed by bundle->dev[0].

Also in greybus gpio driver gb_cport_to_device() was called during each operation to get the cport mapped device, the second commit removes this multiple gb_cport_to_device() calls and use bundle->dev[idx] which has the mapped device stored during driver init.

All changes were tested on CC1352R Sensortag and verified that GPIO, I2C and LED works simultaneously.